### PR TITLE
Fix withdrawal explorer URL

### DIFF
--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -337,7 +337,7 @@
             );
 
             toast.push(`<strong>Withdrawal initiated</strong>
-                <p>click <a href="${blockExplorer}/txt/${
+                <p>click <a href="${blockExplorer}/tx/${
                 tx.hash
             }" target="_blank">here</a> for more details.</p>
                 <p>Withdrawal progress can be tracked on the <a href=${"/account"}>account page</a>.</p>`);


### PR DESCRIPTION
Fix the URL pointing to the block explorer for withdrawals from 'txt' to 'tx'.

Fixes #37 