### PR TITLE
Remove duplicate number input field in bridge overview

### DIFF
--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -514,7 +514,6 @@
         <To
             network={companionNetwork}
             balance={truncateBalance(companionBalance)}
-            balanceAfter={amountToBridge}
             token={selectedToken}
             logo={selectedTokenLogo}
         />

--- a/src/lib/bridge/To.svelte
+++ b/src/lib/bridge/To.svelte
@@ -4,7 +4,6 @@
     export let network = "Unsupported";
     export let token = "ETH";
     export let balance = "0";
-    export let balanceAfter = "0";
     export let logo;
 </script>
 
@@ -20,7 +19,6 @@
     </div>
     <div class="right">
         <p>Balance: {numeral(balance).format("0,0.00")} {token}</p>
-        <input disabled type="number" value={balanceAfter} />
     </div>
 </div>
 

--- a/src/lib/bridge/To.svelte
+++ b/src/lib/bridge/To.svelte
@@ -47,16 +47,6 @@
         margin: 0.5em 0;
     }
 
-    input {
-        border: 0;
-        display: block;
-        text-align: right;
-        font-size: 20px;
-        width: 100%;
-        height: 100%;
-        background-color: var(--text-color-inverse);
-    }
-
     ::placeholder {
         color: var(--text-color-light-grey);
         opacity: 1;


### PR DESCRIPTION
**Purpose**
The duplication of number input fields can cause confusion for users. It also doesn't add any value. Accounting is not displayed in the UX, only current balances and the amount to withdraw or deposit.

**Issues**
Closes #13 

**Changes**
- Remove the disabled number input field in the To component.
- No longer pass the to bridge amount to the To component.

**Check list**
- [x] Code runs without regressions even though new code is incomplete
- [ ] Code reviewer has been explicitly notified outside automatic notification channels
