### PR TITLE
Maximum ETH deposits/withdrawals ignore the gas fee

### DIFF
--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -75,6 +75,7 @@
     $: deposit = L2 === false ? true : false;
 
     const selectToken = () => {
+        amountToBridge = "0";
         isSelectingToken = true;
     };
 
@@ -231,6 +232,7 @@
             blockExplorer = networkDetails.blockExplorerUrls[0];
             await wallet.subscribe(async (accounts) => {
                 address = accounts[0];
+                amountToBridge = "0";
             });
             await getSelectedToken({ detail: { symbol: selectedToken } });
         }

--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -5,6 +5,7 @@
     import { goto } from "$app/navigation";
     import { toast } from "@zerodevx/svelte-toast";
     import {
+        DEPOSIT_ETH_GAS_LIMIT,
         MAX_APPROVAL_AMOUNT,
         NVM_ETH,
         WARNING_L2_ETH_BALANCE,
@@ -349,6 +350,10 @@
                     .standardBridge;
 
                 const requestedAmountToBridge = ethers.utils.parseUnits(amountToBridge);
+                const gasPrice = await provider.getGasPrice();
+                const baseGasCost = gasPrice.mul(BigNumber.from(DEPOSIT_ETH_GAS_LIMIT));
+                // TODO subtract base gas cost from requested amount.
+                // TODO test whether base gas cost is enough, adjust where necessary.
 
                 const tx = await depositETH(
                     standardBridge,
@@ -434,6 +439,11 @@
         }
     };
 
+    const getGasPrices = async () => {
+        console.log(await provider.getGasPrice());
+        console.log(await provider.getFeeData());
+    }
+
     const truncateBalance = (amount) => {
         if (!amount) {
             return "0";
@@ -518,6 +528,8 @@
             token={selectedToken}
             logo={selectedTokenLogo}
         />
+        <Button on:click={getGasPrices}>GET GAS PRICES</Button>
+
         {#if resetApproval}
             <Button on:click={doResetApproval} {disabled}>RESET APPROVAL</Button
             >

--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -62,7 +62,7 @@
     let unsubscribeWallet;
 
     let allowance = 0;
-    let amountToBridge = "0";
+    let amountToBridge = ZERO;
     let tokenBridge;
     let l1Token;
     let blockExplorer;
@@ -75,7 +75,7 @@
     $: deposit = L2 === false ? true : false;
 
     const selectToken = () => {
-        amountToBridge = "0";
+        amountToBridge = ZERO;
         isSelectingToken = true;
     };
 
@@ -93,7 +93,7 @@
         resetApproval = false;
         tokenBridge;
         l1Token;
-        amountToBridge = "0";
+        amountToBridge = ZERO;
         // TODO update bridge address, balances and token symbol
         if (selectedToken == "ETH") {
             selectedTokenLogo = logoETH;
@@ -232,7 +232,7 @@
             blockExplorer = networkDetails.blockExplorerUrls[0];
             await wallet.subscribe(async (accounts) => {
                 address = accounts[0];
-                amountToBridge = "0";
+                amountToBridge = ZERO;
             });
             await getSelectedToken({ detail: { symbol: selectedToken } });
         }
@@ -285,7 +285,7 @@
     const doResetApproval = async () => {
         disabled = true;
         await approve(
-            "0",
+            ZERO,
             `Resetting approval for ${selectedToken} in progress.`,
             `Resetting approval for ${selectedToken} complete.`
         );
@@ -461,7 +461,7 @@
 
     const truncateBalance = (amount) => {
         if (!amount) {
-            return "0";
+            return ZERO;
         }
 
         if (amount.includes(".")) {

--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -358,17 +358,14 @@
                 const requestedAmountPlusMaxFee = requestedAmountToBridge.add(maxFee);
 
                 if (userETHBalance.sub(requestedAmountPlusMaxFee).lt(0)) {
-                    console.log("Balance might be too low!");
                     // Define a safe minimum fee to subtract from the requested amount to bridge if
-                    // a user has a relatively low balance versus what they want to deposit.
+                    // a user has a relatively low remaining balance versus what they want to deposit and the gas cost.
                     // Due to constantly changing network conditions, keep a small safe margin.
                     const basePlusPriority = gasPrice.add(maxPriorityFeePerGas).mul(BigNumber.from(DEPOSIT_ETH_GAS_LIMIT));
-                    // Gas fee inclusive
+                    // Make the gas fee inclusive.
                     requestedAmountToBridge = requestedAmountToBridge.sub(basePlusPriority);
                     const requestedAmountPlusFee = requestedAmountToBridge.add(basePlusPriority);
-                    if (userETHBalance.sub(requestedAmountPlusFee).gte(0)) {
-                        console.log("Gas cost can be covered.");
-                    } else {
+                    if (userETHBalance.sub(requestedAmountPlusFee).lt(0)) {
                         console.log("Gas cost cannot be covered.");
                         // Warn user/block deposit
                         return;

--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -459,37 +459,6 @@
         }
     };
 
-    const getGasPrices = async () => {
-        let requestedAmountToBridge = BigNumber.from("824000004620000");                
-        const {gasPrice, maxFeePerGas, maxPriorityFeePerGas} = await provider.getFeeData();
-        const maxFee = maxFeePerGas.mul(BigNumber.from(DEPOSIT_ETH_GAS_LIMIT));
-        const baseGasCost = gasPrice.mul(BigNumber.from(DEPOSIT_ETH_GAS_LIMIT));
-        const basePlusPriority = baseGasCost.add(maxPriorityFeePerGas);
-        const userETHBalance = ethers.utils.parseEther(balance);
-        console.log("balance: ", userETHBalance.toString())
-        console.log(maxFee.toString());
-        console.log(baseGasCost.toString());
-        console.log(basePlusPriority.toString());
-
-        console.log(requestedAmountToBridge.toString());
-        if (requestedAmountToBridge.sub(maxFee).lt(0)) {
-            console.log("Balance might be too low!");
-            console.log("MaxFee remained:", requestedAmountToBridge.sub(maxFee).toString())
-            console.log("Base+Prio remained:", requestedAmountToBridge.sub(basePlusPriority).toString())
-            if (requestedAmountToBridge.sub(basePlusPriority).gt(0)) {
-                console.log("Gas cost can be covered.");
-                // Subtract base gas cost from requested amount to bridge
-                requestedAmountToBridge = requestedAmountToBridge.sub(basePlusPriority);
-            } else {
-                console.log("Gas cost cannot be covered.");
-                // Warn user/block deposit
-                return;
-            }
-        }
-        console.log(requestedAmountToBridge.toString());
-
-    }
-
     const truncateBalance = (amount) => {
         if (!amount) {
             return "0";
@@ -574,7 +543,6 @@
             token={selectedToken}
             logo={selectedTokenLogo}
         />
-        <Button on:click={getGasPrices}>GET GAS PRICES</Button>
 
         {#if resetApproval}
             <Button on:click={doResetApproval} {disabled}>RESET APPROVAL</Button

--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -27,7 +27,6 @@
     import { findSupportedNetwork } from "../../utils/network";
     import {
         getTokens,
-        getTokensForChain,
         getTokenDetails,
         getTokenBridge,
     } from "../../utils/token";
@@ -79,7 +78,7 @@
         isSelectingToken = true;
     };
 
-    const closeSelectToken = (event) => {
+    const closeSelectToken = () => {
         isSelectingToken = false;
     };
 

--- a/src/lib/bridge/Bridge.svelte
+++ b/src/lib/bridge/Bridge.svelte
@@ -92,6 +92,7 @@
         resetApproval = false;
         tokenBridge;
         l1Token;
+        amountToBridge = "0";
         // TODO update bridge address, balances and token symbol
         if (selectedToken == "ETH") {
             selectedTokenLogo = logoETH;

--- a/src/lib/bridge/From.svelte
+++ b/src/lib/bridge/From.svelte
@@ -82,17 +82,15 @@
     </div>
     <div class="right">
         <p>Balance: {numeral(balance).format("0,0.00")} {token} <Button text="MAX" height="24px" on:click={setMaxValue}></Button></p>
-        <div class="token-details">
-            <input
-                type="number"
-                placeholder="Amount"
-                pattern="^[0-9]*[.]?[0-9]*$"
-                value={amount}
-                min="0"
-                max={balance}
-                on:input={onChange}
-            />
-        </div>
+        <input
+            type="number"
+            placeholder="Amount"
+            pattern="^[0-9]*[.]?[0-9]*$"
+            value={amount}
+            min="0"
+            max={balance}
+            on:input={onChange}
+        />
     </div>
 </div>
 

--- a/src/lib/bridge/From.svelte
+++ b/src/lib/bridge/From.svelte
@@ -21,6 +21,7 @@
     };
 
     function selectTokenModal() {
+        amount = 0;
         dispatch("selectToken");
     }
 

--- a/src/lib/bridge/From.svelte
+++ b/src/lib/bridge/From.svelte
@@ -4,6 +4,7 @@
     numeral.localeData().delimiters.thousands = " ";
     import dropdown from "./dropdown.png";
     import { addAsset } from "../../stores/wallet";
+    import Button from "$lib/shared/Button.svelte";
 
     export let network = "Unsupported";
     export let token = "ETH";
@@ -45,6 +46,13 @@
             amountToBridge: amount,
         });
     };
+
+    const setMaxValue = async () => {
+        amount = balance;
+        dispatch("amountChanged", {
+            amountToBridge: amount,
+        });
+    }
 </script>
 
 <div class="container">
@@ -72,16 +80,18 @@
         {/if}
     </div>
     <div class="right">
-        <p>Balance: {numeral(balance).format("0,0.00")} {token}</p>
-        <input
-            type="number"
-            placeholder="Amount"
-            pattern="^[0-9]*[.]?[0-9]*$"
-            value={amount}
-            min="0"
-            max={balance}
-            on:input={onChange}
-        />
+        <p>Balance: {numeral(balance).format("0,0.00")} {token} <Button text="MAX" height="24px" on:click={setMaxValue}></Button></p>
+        <div class="token-details">
+            <input
+                type="number"
+                placeholder="Amount"
+                pattern="^[0-9]*[.]?[0-9]*$"
+                value={amount}
+                min="0"
+                max={balance}
+                on:input={onChange}
+            />
+        </div>
     </div>
 </div>
 

--- a/src/lib/bridge/From.svelte
+++ b/src/lib/bridge/From.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { createEventDispatcher } from "svelte";
+    import { createEventDispatcher, onMount } from "svelte";
     import numeral from "numeral";
     numeral.localeData().delimiters.thousands = " ";
     import dropdown from "./dropdown.png";
@@ -12,7 +12,12 @@
     export let logo;
     export let address;
     export let decimals;
+    let priorBalance = 0;
     let amount = 0;
+
+    $: if (balance != priorBalance) {
+        amount = 0;
+    }
 
     const dispatch = createEventDispatcher();
 
@@ -54,6 +59,10 @@
             amountToBridge: amount,
         });
     }
+
+    onMount(async () => {
+        priorBalance = balance;
+    });
 </script>
 
 <div class="container">

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,4 @@
-export const DEPOSIT_ETH_GAS_LIMIT = "250000";
+export const DEPOSIT_ETH_GAS_LIMIT = "330000";
 export const DEPOSIT_ERC20_GAS_LIMIT = "375000";
 export const L1L2_NETWORKS = {
     mainnet: ["0x1", "0x15af"],

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,5 @@
+export const DEPOSIT_ETH_GAS_LIMIT = "250000";
+export const DEPOSIT_ERC20_GAS_LIMIT = "375000";
 export const L1L2_NETWORKS = {
     mainnet: ["0x1", "0x15af"],
     testnet: ["0x3", "0x15b1"]


### PR DESCRIPTION
**Purpose**
Fix a situation where the maximum ETH in the UX ignores the gas fee, resulting in there being no funds left to bridge. This solution checks the balances and gas costs pre-transaction execution for low balance wallets, resulting in simplified implementations for #25 and #26.

**Changes**
- Maximum ETH deposits now take a safe gas cost limit into account.
- Max button has been added to max out deposits or withdrawals.
- Reset UI values for certain edge case conditions.

**Issues**
Closes #12 #25 

**Check list**
- [x] Code runs without regressions even though new code is incomplete
- [x] Code reviewer has been explicitly notified outside automatic notification channels
