### PR TITLE
Rebuild withdrawal history.

### DIFF
--- a/src/lib/account/Account.svelte
+++ b/src/lib/account/Account.svelte
@@ -202,6 +202,7 @@
                 transactionType="withdrawals"
                 {fraudProofWindow}
             />
+            <Button on:click={getWithdrawals} height="40px" margin="0 30%">Find withdrawals</Button>
 
             <p>Recent Deposits</p>
             <TransactionTable
@@ -209,8 +210,6 @@
                 transactions={deposits}
                 transactionType="deposits"
             />
-
-            <Button on:click={getWithdrawals}>Test</Button>
         {:else}
             <p class="center">Please connect a wallet.</p>
         {/if}

--- a/src/lib/account/Account.svelte
+++ b/src/lib/account/Account.svelte
@@ -131,7 +131,7 @@
                 return true;
             }
         });
-        // TODO: Trigger UI update on localstorage change.
+        await populateData();
     }
 
     const claimFunds = async (event) => {

--- a/src/lib/account/Account.svelte
+++ b/src/lib/account/Account.svelte
@@ -9,11 +9,14 @@
     import GradientTitle from "$lib/shared/GradientTitle.svelte";
     import { mode } from "$lib/../stores/darkmode";
     import { wallet, network, isConnected, switchNetwork } from "$lib/../stores/wallet";
-    import { getTransactions, updateTransaction } from "$lib/../utils/storage";
+    import { getTransactions, storeTransaction, updateTransaction } from "$lib/../utils/storage";
     import { findCompanionNetwork, findSupportedNetwork, getFraudProofWindow } from "$lib/../utils/network";
     import SmallArrowLeft from "./small-arrow-left.png";
     import SmallArrowLeftDark from "./small-arrow-left-dark.png";
     import Modal from "$lib/shared/Modal.svelte";
+    import Button from "$lib/shared/Button.svelte";
+    import { getTokenDetailsByAddress, getTokens } from "../../utils/token";
+    import { NVM_ETH } from "../../utils/constants";
 
     let connected = false;
     let blocked = false;
@@ -98,6 +101,39 @@
         cleanup();
     });
 
+    const getWithdrawals = async () => {
+        const storedTransactions = getTransactions(chainId, address[0]);
+        const nahmiiExplorerURL = (await findCompanionNetwork(chainId)).blockExplorerUrls[0];
+        const response = await fetch(`${nahmiiExplorerURL}/api?module=account&action=txlist&address=0x4200000000000000000000000000000000000010&page=0&offset=1000&filterby="to"`);
+        const transactions = await response.json();
+        const filteredTransactions = transactions.result.filter(tx => tx.from == address[0]);
+        // Diff for missing withdrawals, store missing ones.
+        const missingWithdrawals = filteredTransactions.filter(async tx => {
+            const hash = storedTransactions.withdrawals.find(element => element.hash == tx.hash);
+            if (hash) {
+                return false;
+            } else {
+                const tokenAddress = `0x${tx.input.substr(34, 40)}`;
+                let ticker;
+                if (tokenAddress == address[0]) {
+                    // Failed withdrawal
+                    storeTransaction(chainId, address[0], "-", { hash: tx.hash, timestamp: parseInt(tx.timeStamp) }, "failed", "withdrawals");
+                } else if (tokenAddress == NVM_ETH) {
+                    ticker = "ETH";
+                    storeTransaction(chainId, address[0], ticker, { hash: tx.hash, timestamp: parseInt(tx.timeStamp) }, "in progress", "withdrawals");
+                } else {
+                    // Find token ticker
+                    const L2ChainId = (await findCompanionNetwork(chainId)).chainId;
+                    const tokenDetails = getTokenDetailsByAddress(tokenAddress, L2ChainId, getTokens());
+                    ticker = tokenDetails.symbol;
+                    storeTransaction(chainId, address[0], ticker, { hash: tx.hash, timestamp: parseInt(tx.timeStamp) }, "in progress", "withdrawals");
+                }
+                return true;
+            }
+        });
+        // TODO: Trigger UI update on localstorage change.
+    }
+
     const claimFunds = async (event) => {
         const { hash, timestamp, token } = event.detail.transaction;
         blocked = true;
@@ -173,6 +209,8 @@
                 transactions={deposits}
                 transactionType="deposits"
             />
+
+            <Button on:click={getWithdrawals}>Test</Button>
         {:else}
             <p class="center">Please connect a wallet.</p>
         {/if}

--- a/src/lib/account/TransactionTable.svelte
+++ b/src/lib/account/TransactionTable.svelte
@@ -65,6 +65,8 @@
 <style>
     .container {
         margin-bottom: 1.5em;
+        max-height: 200px;
+        overflow: auto;
     }
 
     .container:last-of-type {
@@ -77,8 +79,11 @@
     }
 
     th {
-        text-align: left;
+        background-color: white;
         padding: 0.5em 0;
+        position: sticky;
+        text-align: left;
+        top: 0;
     }
 
     tr {
@@ -88,6 +93,18 @@
     td {
         font-size: 0.8em;
         padding: 0.5em 0.1em 0.5em 0;
+    }
+
+    @media (min-height: 960px) {
+        .container {
+            max-height: 250px;
+        }
+    }
+
+    @media (min-height: 1200px) {
+        .container {
+            max-height: 350px;
+        }
     }
 
     @media (min-width: 28em) {

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -58,6 +58,36 @@ export const getTokenDetails = (selectedToken, chainId, tokenList) => {
     }
 }
 
+export const getTokenDetailsByAddress = (tokenAddress, chainId, tokenList) => {
+    const filter = {
+        address: tokenAddress.toLowerCase(),
+        chainId: parseInt(chainId, 16),
+    };
+
+    const result = tokenList.filter(token => {
+        if (token.chainId != filter.chainId) {
+            return false;
+        }
+        if (token.address.toLowerCase() != filter.address) {
+            return false;
+        }
+        return true;
+    });
+
+    if (result) {
+        const { name, symbol, logoURI, address, decimals } = result[0];
+        return {
+            name,
+            symbol,
+            logoURI,
+            address,
+            decimals
+        };
+    } else {
+        return false;
+    }
+}
+
 export const getTokensForChain = (chainId, tokenList) => {
     const filter = {
         chainId: parseInt(chainId, 16),


### PR DESCRIPTION
**Purpose**
Withdrawal history is currently stored in browser based off of user activity. The withdrawal history is not stored on chain in a transparent way, and thus to reconstruct it across multiple devices requires either introspecting past events or retrieving and filtering on chain data through an external data repository like our block explorer.

Preferably, the functionality to filter out withdrawal and deposit events that took place on our bridge would be handled through our SDK. The same for the status introspection of a withdrawal. Since this functionality is not yet available, withdrawal history reconstructing is done through filtering on our block explorers transaction and checking against the input fields of a withdrawal transaction.

**Issues**
#51

**Changes**
- Add token details retrieval through a specified token address.
- Add UI overflow control to the withdrawal history.
- Retrieve, filter and store missing withdrawal transactions.

**Check list**
<!-- Ensure that the following tasks have been completed before code review is requested. -->
- [x] Code runs without regressions even though new code is incomplete
- [ ] Code reviewer has been explicitly notified outside automatic notification channels
